### PR TITLE
fix: rewrite server instructions to focus on workflows

### DIFF
--- a/src/ServerFactory.php
+++ b/src/ServerFactory.php
@@ -256,53 +256,25 @@ class ServerFactory
 
 A demonstration MCP server showcasing PHP SDK capabilities.
 
-## Available Tools
-
-### Greeting & Demos
-- **hello**: Simple greeting - use to test connectivity
-- **get_weather**: Returns simulated weather data
-- **long_task**: Demonstrates progress reporting (takes ~5 seconds)
-
-### LLM Interaction
-- **ask_llm**: Invoke LLM sampling to ask questions (requires client support)
-
-### Dynamic Features
-- **load_bonus_tool**: Dynamically adds a calculator tool at runtime
-- **bonus_calculator**: Available after calling load_bonus_tool
-
-### Elicitation (User Input)
-- **confirm_action**: Demonstrates schema elicitation - requests user confirmation
-- **get_feedback**: Demonstrates URL elicitation - opens feedback form in browser
-
-## Available Resources
-
-- **about://server**: Server information
-- **doc://example**: Sample markdown document
-- **greeting://{name}**: Personalized greeting template
-- **item://{id}**: Item data by ID
-
-## Available Prompts
-
-- **greet**: Generates a personalized greeting
-- **code_review**: Structured code review prompt
-
 ## Recommended Workflows
 
-1. **Testing Connection**: Call `hello` with your name to verify the server is responding
-2. **Weather Demo**: Call `get_weather` with a location to see structured output
-3. **Progress Demo**: Call `long_task` to see progress notifications
-4. **Dynamic Loading**: Call `load_bonus_tool`, then refresh tools to see `bonus_calculator`
-5. **Elicitation Demo**: Call `confirm_action` to see user confirmation flow
-6. **URL Elicitation**: Call `get_feedback` to open a feedback form
+1. **Test connectivity** → Call `hello` to verify the server responds
+2. **Structured output** → Call `get_weather` to see typed response data
+3. **Progress reporting** → Call `long_task` to observe real-time progress notifications
+4. **Dynamic tools** → Call `load_bonus_tool`, then re-list tools to see `bonus_calculator` appear
+5. **LLM sampling** → Call `ask_llm` to have the server request a completion from the client
+6. **Elicitation** → Call `confirm_action` (form-based) or `get_feedback` (URL-based) to request user input
 
-## Tool Annotations
+## Multi-Tool Flows
 
-All tools include annotations indicating:
-- Whether they modify state (readOnlyHint)
-- If they're safe to retry (idempotentHint)
-- Whether they access external systems (openWorldHint)
+- **Full demo**: `hello` → `get_weather` → `long_task` → `load_bonus_tool` → `bonus_calculator`
+- **Dynamic loading**: `load_bonus_tool` triggers a `tools/list_changed` notification — refresh your tool list to see `bonus_calculator`
+- **User interaction**: `confirm_action` demonstrates schema elicitation, `get_feedback` demonstrates URL elicitation
 
-Use these hints to make informed decisions about tool usage.
+## Notes
+
+- All tools include annotations (readOnlyHint, idempotentHint, openWorldHint) to guide safe usage
+- Resources and prompts are available for context and templating — use `resources/list` and `prompts/list` to discover them
 INSTRUCTIONS;
     }
 }


### PR DESCRIPTION
## Summary

Rewrite server instructions to be concise and workflow-focused instead of enumerating every tool, resource, and prompt.

## Philosophy

Server instructions should guide AI assistants on **how to use** the server, not repeat what clients can already discover via `tools/list`, `resources/list`, and `prompts/list`.

## Changes

- Replace verbose tool/resource/prompt enumeration with recommended workflows
- Add multi-tool flow examples showing interesting sequences
- Add notes about tool annotations and resource/prompt discovery
- (Python only) Fix version reporting with `mcp._mcp_server.version = "1.0.0"`

## New Instructions Structure

1. **Recommended Workflows** — numbered steps showing what each tool demonstrates
2. **Multi-Tool Flows** — interesting sequences of operations
3. **Notes** — brief guidance on annotations and discovery