### PR TITLE
chore: add DevContainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+  "name": "MCP PHP Starter",
+  "image": "mcr.microsoft.com/devcontainers/php:1-8.3",
+  "features": {},
+  "postCreateCommand": "composer install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "bmewburn.vscode-intelephense-client",
+        "xdebug.php-debug"
+      ],
+      "settings": {}
+    }
+  },
+  "forwardPorts": [3000],
+  "portsAttributes": {
+    "3000": {
+      "label": "MCP HTTP Server",
+      "onAutoForward": "notify"
+    }
+  }
+}


### PR DESCRIPTION
Adds .devcontainer/devcontainer.json for one-click workshop setup. Uses PHP 8.3 image with Intelephense and Xdebug extensions.